### PR TITLE
[Cicd] Docker 배포 파이프라인 구축

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+.next/cache
+.pnpm-store
+.git
+.gitignore
+Dockerfile
+.dockerignore
+*.log
+.env*

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -86,6 +86,10 @@ jobs:
     env:
       IMAGE: ${{ needs.docker.outputs.image_url }}:sha-${{ needs.docker.outputs.short_sha }}
     steps:
+      # (임시) 러너 출구 IP 출력 (ACG /32 허용 테스트용)
+      - name: Print runner egress IP
+        run: curl -s https://ifconfig.me ; echo
+
       # (임시) 디버그: DEV_HOST, 유저 확인
       - name: Print target info (debug)
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -79,81 +79,47 @@ jobs:
 
 
   deploy-dev:
-    name: Deploy to DEV
+    name: Deploy to DEV (self-hosted)
     needs: docker
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]   # ← 기본 라벨로 매칭
     if: startsWith(github.ref, 'refs/heads/feat/')
     env:
       IMAGE: ${{ needs.docker.outputs.image_url }}:sha-${{ needs.docker.outputs.short_sha }}
+      PROJECT_DIR: ${{ secrets.DEV_PROJECT_DIR }}   # 예: /srv/momuzzi
+      REGISTRY: ${{ vars.REGISTRY }}
     steps:
-      # (임시) 러너 출구 IP 출력 (ACG /32 허용 테스트용)
-      - name: Print runner egress IP
-        run: curl -s https://ifconfig.me ; echo
-
-      # (임시) 디버그: DEV_HOST, 유저 확인
-      - name: Print target info (debug)
+      - name: Docker login
+        run: echo '${{ secrets.REGISTRY_PASSWORD }}' | docker login "$REGISTRY" -u '${{ secrets.REGISTRY_USER }}' --password-stdin
+      - name: Deploy with compose
         run: |
-          echo "HOST=${{ secrets.DEV_HOST }}"
-          echo "USER=${{ secrets.DEV_USER }}"
+          set -Eeuo pipefail
+          test -f "$PROJECT_DIR/deploy/compose.yaml" || { echo "compose.yaml not found"; exit 1; }
+          cd "$PROJECT_DIR"
+          IMAGE='${{ env.IMAGE }}' docker compose -f deploy/compose.yaml pull web
+          IMAGE='${{ env.IMAGE }}' docker compose -f deploy/compose.yaml up -d web
+          sleep 2
+          curl -fsS http://127.0.0.1:3000 >/dev/null && echo "Health OK" || (docker logs web --tail=200 && exit 1)
 
-      # (임시) 디버그: 키 파일 생성
-      - name: Prepare SSH key (debug)
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.DEV_SSH_KEY }}" > ~/.ssh/id_deploy
-          chmod 600 ~/.ssh/id_deploy
-          # 호스트키 검증을 잠시 끄고 시도 (문제 파악용)
-          printf "Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile=/dev/null\n" > ~/.ssh/config
-          chmod 600 ~/.ssh/config
-
-      # (임시) 디버그: 로우 SSH 연결 시도 (왜 타임아웃인지 원인 확인)
-      - name: Raw SSH connectivity test (debug)
-        run: |
-          set -x
-          # 15초 제한으로 시도 (무한 대기 방지)
-          timeout 15s ssh -vvv -i ~/.ssh/id_deploy -p 22 \
-            -o ConnectTimeout=10 \
-            -o BatchMode=yes \
-            -o StrictHostKeyChecking=no \
-            ${{ secrets.DEV_USER }}@${{ secrets.DEV_HOST }} "echo 'SSH OK from runner'"
-
-      # 실제 배포 (원래 있던 스텝)
-      - name: SSH deploy (pull & up)
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.DEV_HOST }}
-          username: ${{ secrets.DEV_USER }}
-          key: ${{ secrets.DEV_SSH_KEY }}      # private key (PEM). 패스프레이즈 있으면 passphrase: 사용
-          script: |
-            docker login ${{ vars.REGISTRY }} -u '${{ secrets.REGISTRY_USER }}' -p '${{ secrets.REGISTRY_PASSWORD }}'
-            cd ${{ secrets.DEV_PROJECT_DIR }}   # 예: /srv/momuzzi (compose.yaml가 있는 위치)
-            IMAGE='${{ env.IMAGE }}' docker compose -f deploy/compose.yaml pull web
-            IMAGE='${{ env.IMAGE }}' docker compose -f deploy/compose.yaml up -d web
-            # 간단 헬스 확인 (필요시)
-            sleep 2
-            curl -fsS http://127.0.0.1:3000 >/dev/null && echo "Health OK" || (docker logs web --tail=200 && exit 1)
 
   deploy-prod:
-    name: Deploy to PROD
+    name: Deploy to PROD (self-hosted)
     needs: docker
-    runs-on: ubuntu-latest
-    # 운영은 main만, 혹은 태그(v*)만
+    runs-on: [self-hosted, Linux, X64]   # prod에도 서버에 러너가 있다면 동일
     if: github.ref == 'refs/heads/main'
-    environment: production       # GitHub Environments에 'production' 만들고 보호 규칙(승인) 추가 가능
+    environment: production
     env:
       IMAGE: ${{ needs.docker.outputs.image_url }}:sha-${{ needs.docker.outputs.short_sha }}
-
+      PROJECT_DIR: ${{ secrets.PROD_PROJECT_DIR }}
+      REGISTRY: ${{ vars.REGISTRY }}
     steps:
-      - name: SSH deploy (pull & up)
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.PROD_HOST }}
-          username: ${{ secrets.PROD_USER }}
-          key: ${{ secrets.PROD_SSH_KEY }}
-          script: |
-            docker login ${{ vars.REGISTRY }} -u '${{ secrets.REGISTRY_USER }}' -p '${{ secrets.REGISTRY_PASSWORD }}'
-            cd ${{ secrets.PROD_PROJECT_DIR }}  # 예: /srv/momuzzi
-            IMAGE='${{ env.IMAGE }}' docker compose -f deploy/compose.yaml pull web
-            IMAGE='${{ env.IMAGE }}' docker compose -f deploy/compose.yaml up -d web
-            sleep 2
-            curl -fsS http://127.0.0.1:3000 >/dev/null && echo "Health OK" || (docker logs web --tail=200 && exit 1)
+      - name: Docker login
+        run: echo '${{ secrets.REGISTRY_PASSWORD }}' | docker login "$REGISTRY" -u '${{ secrets.REGISTRY_USER }}' --password-stdin
+      - name: Deploy with compose
+        run: |
+          set -Eeuo pipefail
+          test -f "$PROJECT_DIR/deploy/compose.yaml" || { echo "compose.yaml not found"; exit 1; }
+          cd "$PROJECT_DIR"
+          IMAGE='${{ env.IMAGE }}' docker compose -f deploy/compose.yaml pull web
+          IMAGE='${{ env.IMAGE }}' docker compose -f deploy/compose.yaml up -d web
+          sleep 2
+          curl -fsS http://127.0.0.1:3000 >/dev/null && echo "Health OK" || (docker logs web --tail=200 && exit 1)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,7 +65,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}:cache
+          cache-from: typcorepack prepare pnpm@pnpm@10.15 add --no-cache libc6-compate=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}:cache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}:cache,mode=max
 
       - name: Show image digest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,12 @@ name: Build & Push Docker
 on:
   push:
     branches: [ main, feat/docker-deploy ]
+    tags: [ 'v*' ]           # 태그 푸시 시 버전 태깅도 지원 (선택)
   workflow_dispatch: {}
+
+concurrency:
+  group: docker-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   docker:
@@ -11,6 +16,14 @@ jobs:
     permissions:
       contents: read
       packages: write
+
+    env:
+      # 레지스트리/리포는 Secrets로 주입 (Docker Hub 예시)
+      # REGISTRY=docker.io
+      # IMAGE_REPO=<dockerhub-id>/<repo>
+      REGISTRY: ${{ vars.REGISTRY }}
+      IMAGE_REPO: ${{ vars.IMAGE_REPO }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -20,17 +33,40 @@ jobs:
       - name: Login to Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ secrets.REGISTRY }}
+          registry: ${{ env.REGISTRY }}
           username: ${{ secrets.REGISTRY_USER }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
 
+      - name: Extract short SHA
+        id: vars
+        run: echo "SHORT_SHA=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}
+          # 태그 정책:
+          # - main 브랜치: latest
+          # - 모든 커밋: sha-<7자리>
+          # - 태그 이벤트(v*): 그 태그 이름으로도 푸시
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=sha-${{ steps.vars.outputs.SHORT_SHA }}
+            type=ref,event=tag
+
       - name: Build & Push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ secrets.REGISTRY }}/${{ secrets.IMAGE_REPO }}:${{ github.sha }}
-          cache-from: type=registry,ref=${{ secrets.REGISTRY }}/${{ secrets.IMAGE_REPO }}:cache
-          cache-to: type=registry,ref=${{ secrets.REGISTRY }}/${{ secrets.IMAGE_REPO }}:cache,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}:cache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}:cache,mode=max
+
+      - name: Show image digest
+        run: echo "Pushed digest ${{ steps.build.outputs.digest }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,8 +65,11 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: typcorepack prepare pnpm@pnpm@10.15 add --no-cache libc6-compate=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}:cache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}:cache,mode=max
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+#          cache-from: typcorepack prepare pnpm@pnpm@10.15e=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}:cache
+#          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}:cache,mode=max
 
       - name: Show image digest
         run: echo "Pushed digest ${{ steps.build.outputs.digest }}"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    outputs:
+      short_sha: ${{ steps.vars.outputs.SHORT_SHA }}
+      image_url: ${{ env.REGISTRY }}/${{ env.IMAGE_REPO }} # docker.io/journey1019/depromeet-team3
 
     env:
       # 레지스트리/리포는 Secrets로 주입 (Docker Hub 예시)
@@ -73,3 +76,54 @@ jobs:
 
       - name: Show image digest
         run: echo "Pushed digest ${{ steps.build.outputs.digest }}"
+
+
+  deploy-dev:
+    name: Deploy to DEV
+    needs: docker
+    runs-on: ubuntu-latest
+    # 예: feat/* 브랜치만 dev로
+    if: startsWith(github.ref, 'refs/heads/feat/')
+    env:
+      IMAGE: ${{ needs.docker.outputs.image_url }}:sha-${{ needs.docker.outputs.short_sha }}
+
+    steps:
+      - name: SSH deploy (pull & up)
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEV_HOST }}
+          username: ${{ secrets.DEV_USER }}
+          key: ${{ secrets.DEV_SSH_KEY }}      # private key (PEM). 패스프레이즈 있으면 passphrase: 사용
+          script: |
+            docker login ${{ vars.REGISTRY }} -u '${{ secrets.REGISTRY_USER }}' -p '${{ secrets.REGISTRY_PASSWORD }}'
+            cd ${{ secrets.DEV_PROJECT_DIR }}   # 예: /srv/momuzzi (compose.yaml가 있는 위치)
+            IMAGE='${{ env.IMAGE }}' docker compose -f deploy/compose.yaml pull web
+            IMAGE='${{ env.IMAGE }}' docker compose -f deploy/compose.yaml up -d web
+            # 간단 헬스 확인 (필요시)
+            sleep 2
+            curl -fsS http://127.0.0.1:3000 >/dev/null && echo "Health OK" || (docker logs web --tail=200 && exit 1)
+
+  deploy-prod:
+    name: Deploy to PROD
+    needs: docker
+    runs-on: ubuntu-latest
+    # 운영은 main만, 혹은 태그(v*)만
+    if: github.ref == 'refs/heads/main'
+    environment: production       # GitHub Environments에 'production' 만들고 보호 규칙(승인) 추가 가능
+    env:
+      IMAGE: ${{ needs.docker.outputs.image_url }}:sha-${{ needs.docker.outputs.short_sha }}
+
+    steps:
+      - name: SSH deploy (pull & up)
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.PROD_HOST }}
+          username: ${{ secrets.PROD_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          script: |
+            docker login ${{ vars.REGISTRY }} -u '${{ secrets.REGISTRY_USER }}' -p '${{ secrets.REGISTRY_PASSWORD }}'
+            cd ${{ secrets.PROD_PROJECT_DIR }}  # 예: /srv/momuzzi
+            IMAGE='${{ env.IMAGE }}' docker compose -f deploy/compose.yaml pull web
+            IMAGE='${{ env.IMAGE }}' docker compose -f deploy/compose.yaml up -d web
+            sleep 2
+            curl -fsS http://127.0.0.1:3000 >/dev/null && echo "Health OK" || (docker logs web --tail=200 && exit 1)

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,14 +24,12 @@ jobs:
       # 레지스트리/리포는 Secrets로 주입 (Docker Hub 예시)
       # REGISTRY=docker.io
       # IMAGE_REPO=<dockerhub-id>/<repo>
-      REGISTRY: ${{ vars.REGISTRY }}
-      IMAGE_REPO: ${{ vars.IMAGE_REPO }}
+      REGISTRY: ${{ vars.REGISTRY != '' && vars.REGISTRY || 'docker.io' }}
+      IMAGE_REPO: ${{ vars.IMAGE_REPO != '' && vars.IMAGE_REPO || 'journey1019/depromeet-team3' }}
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v3
 
       - name: Login to Registry
         uses: docker/login-action@v3
@@ -71,8 +69,15 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-#          cache-from: typcorepack prepare pnpm@pnpm@10.15e=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}:cache
-#          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}:cache,mode=max
+      - name: Compute image URL
+        id: outs
+        run: |
+          set -e
+          if [ -z "${{ env.REGISTRY }}" ] || [ -z "${{ env.IMAGE_REPO }}" ]; then
+            echo "REGISTRY or IMAGE_REPO is empty"; exit 1
+          fi
+          echo "IMAGE_URL=${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}" >> "$GITHUB_OUTPUT"
+          echo "Resolved IMAGE_URL=${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}"
 
       - name: Show image digest
         run: echo "Pushed digest ${{ steps.build.outputs.digest }}"
@@ -86,7 +91,8 @@ jobs:
     env:
       IMAGE: ${{ needs.docker.outputs.image_url }}:sha-${{ needs.docker.outputs.short_sha }}
       PROJECT_DIR: ${{ secrets.DEV_PROJECT_DIR }}   # 예: /srv/momuzzi
-      REGISTRY: ${{ vars.REGISTRY }}
+      REGISTRY: ${{ vars.REGISTRY != '' && vars.REGISTRY || 'docker.io' }}
+
     steps:
       - name: Print resolved image (debug)
         run: echo "IMAGE=${IMAGE}"   # ✅ 여기서 docker.io/계정/레포:sha-xxxx 가 찍혀야 정상

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,7 +18,7 @@ jobs:
       packages: write
     outputs:
       short_sha: ${{ steps.vars.outputs.SHORT_SHA }}
-      image_url: ${{ env.REGISTRY }}/${{ env.IMAGE_REPO }} # docker.io/journey1019/depromeet-team3
+      image_url: ${{ steps.outs.outputs.IMAGE_URL }} # docker.io/journey1019/depromeet-team3
 
     env:
       # 레지스트리/리포는 Secrets로 주입 (Docker Hub 예시)
@@ -88,8 +88,12 @@ jobs:
       PROJECT_DIR: ${{ secrets.DEV_PROJECT_DIR }}   # 예: /srv/momuzzi
       REGISTRY: ${{ vars.REGISTRY }}
     steps:
+      - name: Print resolved image (debug)
+        run: echo "IMAGE=${IMAGE}"   # ✅ 여기서 docker.io/계정/레포:sha-xxxx 가 찍혀야 정상
+
       - name: Docker login
         run: echo '${{ secrets.REGISTRY_PASSWORD }}' | docker login "$REGISTRY" -u '${{ secrets.REGISTRY_USER }}' --password-stdin
+
       - name: Deploy with compose
         run: |
           set -Eeuo pipefail

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -89,13 +89,23 @@ jobs:
     runs-on: [self-hosted, Linux, X64]   # ← 기본 라벨로 매칭
     if: startsWith(github.ref, 'refs/heads/feat/')
     env:
-      IMAGE: ${{ needs.docker.outputs.image_url }}:sha-${{ needs.docker.outputs.short_sha }}
+      # 레지스트리/레포 기본값 포함해서 안전하게 조립
+      IMAGE: ${{ format(
+        '{0}/{1}:sha-{2}',
+        (vars.REGISTRY || 'docker.io'),
+        (vars.IMAGE_REPO || 'journey1019/depromeet-team3'),
+        needs.docker.outputs.short_sha) }}
+
       PROJECT_DIR: ${{ secrets.DEV_PROJECT_DIR }}   # 예: /srv/momuzzi
       REGISTRY: ${{ vars.REGISTRY != '' && vars.REGISTRY || 'docker.io' }}
 
     steps:
       - name: Print resolved image (debug)
-        run: echo "IMAGE=${IMAGE}"   # ✅ 여기서 docker.io/계정/레포:sha-xxxx 가 찍혀야 정상
+        run: |
+          echo "REGISTRY=${{ vars.REGISTRY }}"
+          echo "IMAGE_REPO=${{ vars.IMAGE_REPO }}"
+          echo "SHORT_SHA=${{ needs.docker.outputs.short_sha }}"
+          echo "IMAGE=${IMAGE}"   # ✅ 여기서 docker.io/계정/레포:sha-xxxx 가 찍혀야 정상
 
       - name: Docker login
         run: echo '${{ secrets.REGISTRY_PASSWORD }}' | docker login "$REGISTRY" -u '${{ secrets.REGISTRY_USER }}' --password-stdin

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,36 @@
+name: Build & Push Docker
+
+on:
+  push:
+    branches: [ main, feat/docker-deploy ]
+  workflow_dispatch: {}
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.REGISTRY }}
+          username: ${{ secrets.REGISTRY_USER }}
+          password: ${{ secrets.REGISTRY_PASSWORD }}
+
+      - name: Build & Push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ secrets.REGISTRY }}/${{ secrets.IMAGE_REPO }}:${{ github.sha }}
+          cache-from: type=registry,ref=${{ secrets.REGISTRY }}/${{ secrets.IMAGE_REPO }}:cache
+          cache-to: type=registry,ref=${{ secrets.REGISTRY }}/${{ secrets.IMAGE_REPO }}:cache,mode=max

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,7 @@ name: Build & Push Docker
 
 on:
   push:
-    branches: [ main, feat/docker-deploy ]
+    branches: [ main, feat/* ]
     tags: [ 'v*' ]           # 태그 푸시 시 버전 태깅도 지원 (선택)
   workflow_dispatch: {}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -82,12 +82,38 @@ jobs:
     name: Deploy to DEV
     needs: docker
     runs-on: ubuntu-latest
-    # 예: feat/* 브랜치만 dev로
     if: startsWith(github.ref, 'refs/heads/feat/')
     env:
       IMAGE: ${{ needs.docker.outputs.image_url }}:sha-${{ needs.docker.outputs.short_sha }}
-
     steps:
+      # (임시) 디버그: DEV_HOST, 유저 확인
+      - name: Print target info (debug)
+        run: |
+          echo "HOST=${{ secrets.DEV_HOST }}"
+          echo "USER=${{ secrets.DEV_USER }}"
+
+      # (임시) 디버그: 키 파일 생성
+      - name: Prepare SSH key (debug)
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEV_SSH_KEY }}" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
+          # 호스트키 검증을 잠시 끄고 시도 (문제 파악용)
+          printf "Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile=/dev/null\n" > ~/.ssh/config
+          chmod 600 ~/.ssh/config
+
+      # (임시) 디버그: 로우 SSH 연결 시도 (왜 타임아웃인지 원인 확인)
+      - name: Raw SSH connectivity test (debug)
+        run: |
+          set -x
+          # 15초 제한으로 시도 (무한 대기 방지)
+          timeout 15s ssh -vvv -i ~/.ssh/id_deploy -p 22 \
+            -o ConnectTimeout=10 \
+            -o BatchMode=yes \
+            -o StrictHostKeyChecking=no \
+            ${{ secrets.DEV_USER }}@${{ secrets.DEV_HOST }} "echo 'SSH OK from runner'"
+
+      # 실제 배포 (원래 있던 스텝)
       - name: SSH deploy (pull & up)
         uses: appleboy/ssh-action@v1
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -128,10 +128,18 @@ jobs:
     if: github.ref == 'refs/heads/main'
     environment: production
     env:
-      IMAGE: ${{ needs.docker.outputs.image_url }}:sha-${{ needs.docker.outputs.short_sha }}
+      IMAGE: ${{ format(
+        '{0}/{1}:sha-{2}',
+        (vars.REGISTRY || 'docker.io'),
+        (vars.IMAGE_REPO || 'journey1019/depromeet-team3'),
+        needs.docker.outputs.short_sha) }}
       PROJECT_DIR: ${{ secrets.PROD_PROJECT_DIR }}
-      REGISTRY: ${{ vars.REGISTRY }}
+      REGISTRY: ${{ vars.REGISTRY || 'docker.io' }}
     steps:
+      - name: Print resolved image (debug)
+        run: |
+          echo "IMAGE=${IMAGE}"
+          echo "PROJECT_DIR=${PROJECT_DIR}"
       - name: Docker login
         run: echo '${{ secrets.REGISTRY_PASSWORD }}' | docker login "$REGISTRY" -u '${{ secrets.REGISTRY_USER }}' --password-stdin
       - name: Deploy with compose

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,28 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+docker.env
+*.secrets
+*.secret
+
+# 로컬만 쓰는 compose 오버라이드(팀 규칙에 맞게 패턴 선택)
+docker-compose.override.yml
+docker-compose.*.local.yml
+compose.*.local.yml
+
+# 인증/키/자격 증명
+*.pem
+*.key
+*.crt
+*.pfx
+*.p12
+.ssh/
+id_rsa*
+id_ed25519*
+known_hosts
+
+# 혹시 누가 실수로 넣을 수 있는 도커 설정 폴더
+.docker/
 
 # vercel
 .vercel

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ known_hosts
 
 # 혹시 누가 실수로 넣을 수 있는 도커 설정 폴더
 .docker/
+# docker
+deploy_key
+deploy_key.pub
 
 # vercel
 .vercel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,67 @@
+# syntax=docker/dockerfile:1
+
+############################
+# 1) base
+############################
+FROM node:22-alpine AS base
+WORKDIR /app
+ENV NODE_ENV=production
+# Next 이미지 최적화/네이티브 모듈 호환을 위한 권장 패키지
+RUN apk add --no-cache libc6-compat
+# pnpm 사용
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+############################
+# 2) deps: 의존성 설치 (캐시 레이어)
+############################
+FROM base AS deps
+COPY package.json pnpm-lock.yaml ./
+# 개발용 prepare/postinstall(= lefthook 등) 스킵
+RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile --ignore-scripts
+
+# (선택) 네이티브 모듈이 있고 Alpine 프리빌트가 없으면 아래 주석 해제
+# RUN apk add --no-cache --virtual .build-deps python3 make g++ \
+#   && pnpm rebuild \
+#   && apk del .build-deps
+
+############################
+# 3) builder: 소스 복사 + 빌드
+############################
+FROM base AS builder
+ENV NEXT_TELEMETRY_DISABLED=1
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+# (선택) 빌드에 필요한 바이너리만 선별 재빌드
+#  - sharp / @tailwindcss/oxide 가 필요하면 해제
+# RUN pnpm rebuild sharp @tailwindcss/oxide
+
+RUN pnpm build
+
+############################
+# 4) runner: 경량 런타임
+############################
+FROM node:22-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+ENV HOSTNAME=0.0.0.0
+ENV PORT=3000
+
+# 보안상 비루트 사용자
+RUN addgroup -S nodejs && adduser -S nextjs -G nodejs
+
+# 정적/런타임 산출물만 복사(standalone)
+COPY --chown=nextjs:nodejs --from=builder /app/public ./public
+COPY --chown=nextjs:nodejs --from=builder /app/.next/standalone ./
+COPY --chown=nextjs:nodejs --from=builder /app/.next/static ./.next/static
+
+USER nextjs
+EXPOSE 3000
+
+# 간단 헬스체크 (busybox wget)
+HEALTHCHECK --interval=10s --timeout=3s --retries=5 \
+CMD wget -qO- http://127.0.0.1:3000/ >/dev/null 2>&1 || exit 1
+
+# server.js 는 standalone 빌드에서 생성됨
+CMD ["node", "server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV NODE_ENV=production
 # Next 이미지 최적화/네이티브 모듈 호환을 위한 권장 패키지
 RUN apk add --no-cache libc6-compat
 # pnpm 사용
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@pnpm@10.15.0 --activate
 
 ############################
 # 2) deps: 의존성 설치 (캐시 레이어)

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ ENV NODE_ENV=production
 # Next 이미지 최적화/네이티브 모듈 호환을 위한 권장 패키지
 RUN apk add --no-cache libc6-compat
 # pnpm 사용
-RUN corepack enable && corepack prepare pnpm@pnpm@10.15.0 --activate
+ARG PNPM_VERSION=10.15.0
+RUN corepack enable && corepack prepare "pnpm@${PNPM_VERSION}" --activate
 
 ############################
 # 2) deps: 의존성 설치 (캐시 레이어)

--- a/README_deploy.md
+++ b/README_deploy.md
@@ -1,0 +1,279 @@
+# README_deploy.md
+
+## 개요
+
+프론트엔드(Next.js) 애플리케이션을 **Docker 이미지**로 빌드하여 **Docker Hub**에 푸시하고,
+
+**NCP VM** 서버에 **SSH + Docker Compose**로 배포하는 CI/CD 가이드입니다.
+
+- CI: **GitHub Actions**
+- Registry: **Docker Hub** (`docker.io`)
+- CD: **NCP VM** (Ubuntu, Docker/Compose)
+- 배포 파일: `deploy/compose.yaml`
+- Dockerfile: 멀티-스테이지(install → build → run), Next.js **standalone** 모드
+
+---
+
+## TL;DR
+
+- 브랜치 푸시하면 이미지가 빌드/태깅/푸시됩니다.
+- `feat/*` 브랜치 → **DEV 자동 배포**
+- `main` 브랜치 → **PROD 자동 배포**(필요시 환경 승인)
+- 롤백: 이전 커밋의 `sha-<7>` 태그로 `compose up -d` 재기동
+
+---
+
+## 레포 구조(배포 관련)
+
+```
+.
+├─ .github/workflows/docker.yml     # 빌드/푸시 + DEV/PROD 배포 워크플로
+├─ deploy/
+│  └─ compose.yaml                  # 서버에서 실행할 Docker Compose 파일
+├─ Dockerfile                       # Next.js 빌드/런타임 이미지
+└─ README_deploy.md                 # ← 이 문서
+
+```
+
+---
+
+## 파이프라인 개요
+
+```
+Dev/Feat push ─┐
+               ├─ GitHub Actions (docker)
+               │     ├─ docker build (Next.js standalone)
+               │     ├─ docker push → Docker Hub
+               │     └─ 태깅: sha-<7>, (main이면 latest도)
+               └─ (deploy-dev) SSH → NCP VM → docker compose up -d web
+
+main push ─────┤
+               └─ (deploy-prod) SSH → NCP VM → docker compose up -d web
+
+```
+
+---
+
+## GitHub Actions 설정
+
+### Variables (Repository → Settings → Actions → Variables)
+
+| 키           | 값(예시)                      | 설명                |
+| ------------ | ----------------------------- | ------------------- |
+| `REGISTRY`   | `docker.io`                   | 컨테이너 레지스트리 |
+| `IMAGE_REPO` | `journey1019/depromeet-team3` | `<계정>/<레포>`     |
+
+### Secrets (Repository → Settings → Actions → Secrets)
+
+| 키                   | 값(예시)                                  | 설명                                       |
+| -------------------- | ----------------------------------------- | ------------------------------------------ |
+| `REGISTRY_USER`      | `journey1019`                             | Docker Hub 아이디                          |
+| `REGISTRY_PASSWORD`  | `<Docker Hub PAT>`                        | Docker Hub Personal Access Token           |
+| `DEV_HOST`           | `<DEV 서버 IP/호스트>`                    | 예: `203.0.113.10`                         |
+| `DEV_USER`           | `ubuntu`                                  | DEV SSH 사용자                             |
+| `DEV_SSH_KEY`        | `-----BEGIN OPENSSH PRIVATE KEY----- ...` | **배포 전용 개인키** 전체 내용             |
+| `DEV_SSH_PASSPHRASE` | (선택)                                    | 개인키 패스프레이즈 사용 시                |
+| `DEV_PROJECT_DIR`    | `/srv/momuzzi`                            | 서버에서 `deploy/compose.yaml`이 있는 경로 |
+| `PROD_HOST`          | (선택)                                    | PROD 서버 IP/호스트                        |
+| `PROD_USER`          | (선택)                                    | PROD SSH 사용자                            |
+| `PROD_SSH_KEY`       | (선택)                                    | PROD 배포 키                               |
+| `PROD_PROJECT_DIR`   | (선택)                                    | PROD 배포 경로                             |
+
+> 보안 TIP: 서버 호스트키 지문을 DEV_SSH_FINGERPRINT로 저장하고, 워크플로에 fingerprint:를 추가하면 MITM 방어가 강화됩니다.
+
+---
+
+## 서버(1회) 준비
+
+1. **Docker & Compose 설치 확인**
+
+```bash
+docker version
+docker compose version
+
+```
+
+1. **배포 디렉토리 준비**
+
+```bash
+sudo mkdir -p /srv/momuzzi
+sudo chown <ssh-user>:<ssh-user> /srv/momuzzi
+# 예: ubuntu 사용자라면 ubuntu:ubuntu
+
+```
+
+1. **compose 파일 배치**
+
+- 방법 A) 서버에 레포를 클론하여 `/srv/momuzzi/deploy/compose.yaml` 경로 유지
+- 방법 B) `deploy/` 폴더만 서버로 복사
+
+1. (권장) **ubuntu를 docker 그룹에 추가**
+
+```bash
+sudo usermod -aG docker ubuntu
+# 재로그인 후 반영
+
+```
+
+1. **배포 키 등록**(백엔드/인프라 팀이 수행)
+
+- 프론트가 제공한 `deploy_key.pub` **한 줄 전체**를 서버의 `~/.ssh/authorized_keys`에 추가
+
+```bash
+mkdir -p ~/.ssh && chmod 700 ~/.ssh
+touch ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys
+echo "<deploy_key.pub 한 줄>" >> ~/.ssh/authorized_keys
+
+```
+
+---
+
+## compose 설정
+
+`deploy/compose.yaml`(요약):
+
+```yaml
+services:
+  web:
+    image: ${IMAGE} # Actions에서 IMAGE='레포:태그'로 주입
+    # platform: linux/amd64    # (옵션) macOS/ARM 로컬 테스트 시 유용
+    ports:
+      - '3000:3000' # dev 충돌 시 "3001:3000"
+    environment:
+      NODE_ENV: production
+    restart: unless-stopped
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://127.0.0.1:3000/ >/dev/null 2>&1 || exit 1']
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+```
+
+> 서버에서 수동 테스트(예시):
+>
+> `IMAGE="docker.io/journey1019/depromeet-team3:sha-xxxxxxx" docker compose -f deploy/compose.yaml up -d`
+
+---
+
+## Dockerfile(요약)
+
+- `node:22-alpine` 기반 멀티 스테이지
+- `corepack`으로 pnpm 고정 (`ARG PNPM_VERSION`)
+- Next.js **standalone** 빌드 결과만 런타임 이미지에 포함
+- `HEALTHCHECK` 포함, `node server.js`로 기동
+
+---
+
+## 개발자 플로우
+
+### 1) 자동 배포
+
+- **feat/** 브랜치에 push → DEV 자동 배포
+- **main** 브랜치에 push → PROD 자동 배포
+
+### 2) 수동 배포(서버에서)
+
+```bash
+export IMAGE=docker.io/journey1019/depromeet-team3:sha-<7자리>
+cd /srv/momuzzi
+IMAGE="$IMAGE" docker compose -f deploy/compose.yaml pull web
+IMAGE="$IMAGE" docker compose -f deploy/compose.yaml up -d web
+
+```
+
+### 3) 롤백
+
+- 원하는 과거 커밋의 `sha-<7>` 태그로 재기동
+
+```bash
+export IMAGE=docker.io/journey1019/depromeet-team3:sha-<이전7자리>
+IMAGE="$IMAGE" docker compose -f deploy/compose.yaml up -d web
+
+```
+
+### 4) 헬스/로그
+
+```bash
+curl -I http://127.0.0.1:3000 | head -n1
+docker logs -f web
+
+```
+
+---
+
+## 로컬 스모크 테스트(옵션)
+
+Apple Silicon(M1/M2)에서 amd64 이미지를 돌릴 때:
+
+```bash
+TAG=sha-xxxxxxx
+IMG=docker.io/journey1019/depromeet-team3:$TAG
+docker pull --platform=linux/amd64 "$IMG"
+docker run --platform=linux/amd64 -d --rm --name web -p 3001:3000 "$IMG"
+curl -I http://127.0.0.1:3001 | head -n1
+docker stop web
+
+```
+
+---
+
+## 레지스트리 전환(NCP 사설 레지스트리)
+
+- `REGISTRY=registry.momuzzi.site`
+- `IMAGE_REPO=<네임스페이스>/<레포>`
+- 서버/Actions 모두 `docker login registry.momuzzi.site` 로 조정
+- SSL/TLS 인증서(정상) 필요
+
+---
+
+## 멀티아키 빌드(선택)
+
+GitHub Actions에서:
+
+```yaml
+- uses: docker/setup-qemu-action@v3
+- uses: docker/build-push-action@v6
+  with:
+    platforms: linux/amd64,linux/arm64
+    cache-from: type=gha
+    cache-to: type=gha,mode=max
+```
+
+> 네이티브 모듈(sharp 등) 사용 시 Alpine에서 리빌드가 필요할 수 있음.
+
+---
+
+## 트러블슈팅(자주 만난 케이스)
+
+- **no matching manifest for linux/arm64**
+
+  → 로컬이 ARM인데 이미지가 amd64 전용. `--platform=linux/amd64`로 실행하거나 멀티아키로 빌드.
+
+- **Bind for 0.0.0.0:3000 failed: port is already allocated**
+
+  → 포트 충돌. 기존 컨테이너 종료 또는 `ports: "3001:3000"`로 변경.
+
+- **Cannot connect to the Docker daemon**
+
+  → Docker 데몬 미기동. Docker Desktop/서비스 재시작, `docker context use desktop-linux`.
+
+- **can't connect without a private SSH key or password**
+
+  → Actions의 `key:`(개인키) 누락. `DEV_SSH_KEY` Secrets 재확인.
+
+- **Permission denied (publickey)** 또는 **Broken pipe**
+
+  → 서버 `~/.ssh/authorized_keys`에 공개키 미등록 또는 권한(700/600) 문제.
+
+- **IMAGE 변수 미설정으로 compose 실패**
+
+  → 배포 시 `IMAGE='<레포:태그>' docker compose ...` 형태로 주입 필요(워크플로에서 처리).
+
+---
+
+## 부록: 팀 공유용 요약(한 줄)
+
+> CI는 GitHub Actions, CD는 NCP VM(SSH+Docker Compose).
+>
+> 도커 이미지는 Docker Hub에 `latest/sha-<7>`로 푸시, 서버는 `deploy/compose.yaml`로 기동.

--- a/README_deploy.md
+++ b/README_deploy.md
@@ -4,11 +4,11 @@
 
 프론트엔드(Next.js) 애플리케이션을 **Docker 이미지**로 빌드하여 **Docker Hub**에 푸시하고,
 
-**NCP VM** 서버에 **SSH + Docker Compose**로 배포하는 CI/CD 가이드입니다.
+**NCP VM 내부의 Self-Hosted Runner**가 서버에서 직접 **Docker Compose**로 배포하는 CI/CD 가이드입니다.
 
 - CI: **GitHub Actions**
 - Registry: **Docker Hub** (`docker.io`)
-- CD: **NCP VM** (Ubuntu, Docker/Compose)
+- CD: **Self-Hosted Runner on NCP VM**
 - 배포 파일: `deploy/compose.yaml`
 - Dockerfile: 멀티-스테이지(install → build → run), Next.js **standalone** 모드
 
@@ -17,8 +17,8 @@
 ## TL;DR
 
 - 브랜치 푸시하면 이미지가 빌드/태깅/푸시됩니다.
-- `feat/*` 브랜치 → **DEV 자동 배포**
-- `main` 브랜치 → **PROD 자동 배포**(필요시 환경 승인)
+- `feat/*` → **DEV 자동 배포** (self-hosted runner)
+- `main` → **PROD 자동 배포** (self-hosted runner)
 - 롤백: 이전 커밋의 `sha-<7>` 태그로 `compose up -d` 재기동
 
 ---
@@ -45,10 +45,10 @@ Dev/Feat push ─┐
                │     ├─ docker build (Next.js standalone)
                │     ├─ docker push → Docker Hub
                │     └─ 태깅: sha-<7>, (main이면 latest도)
-               └─ (deploy-dev) SSH → NCP VM → docker compose up -d web
+               └─ (deploy-dev) Self-Hosted Runner → docker compose up -d web
 
 main push ─────┤
-               └─ (deploy-prod) SSH → NCP VM → docker compose up -d web
+               └─ (deploy-prod) Self-Hosted Runner → docker compose up -d web
 
 ```
 
@@ -65,21 +65,14 @@ main push ─────┤
 
 ### Secrets (Repository → Settings → Actions → Secrets)
 
-| 키                   | 값(예시)                                  | 설명                                       |
-| -------------------- | ----------------------------------------- | ------------------------------------------ |
-| `REGISTRY_USER`      | `journey1019`                             | Docker Hub 아이디                          |
-| `REGISTRY_PASSWORD`  | `<Docker Hub PAT>`                        | Docker Hub Personal Access Token           |
-| `DEV_HOST`           | `<DEV 서버 IP/호스트>`                    | 예: `203.0.113.10`                         |
-| `DEV_USER`           | `ubuntu`                                  | DEV SSH 사용자                             |
-| `DEV_SSH_KEY`        | `-----BEGIN OPENSSH PRIVATE KEY----- ...` | **배포 전용 개인키** 전체 내용             |
-| `DEV_SSH_PASSPHRASE` | (선택)                                    | 개인키 패스프레이즈 사용 시                |
-| `DEV_PROJECT_DIR`    | `/srv/momuzzi`                            | 서버에서 `deploy/compose.yaml`이 있는 경로 |
-| `PROD_HOST`          | (선택)                                    | PROD 서버 IP/호스트                        |
-| `PROD_USER`          | (선택)                                    | PROD SSH 사용자                            |
-| `PROD_SSH_KEY`       | (선택)                                    | PROD 배포 키                               |
-| `PROD_PROJECT_DIR`   | (선택)                                    | PROD 배포 경로                             |
+| 키                  | 값(예시)              | 설명                                       |
+| ------------------- | --------------------- | ------------------------------------------ |
+| `REGISTRY_USER`     | `journey1019`         | Docker Hub 아이디                          |
+| `REGISTRY_PASSWORD` | `<Docker Hub PAT>`    | Docker Hub Personal Access Token           |
+| `DEV_PROJECT_DIR`   | `/srv/momuzzi`        | 서버에서 `deploy/compose.yaml` 경로의 루트 |
+| `PROD_PROJECT_DIR`  | (선택) `/srv/momuzzi` | PROD 배포 경로                             |
 
-> 보안 TIP: 서버 호스트키 지문을 DEV_SSH_FINGERPRINT로 저장하고, 워크플로에 fingerprint:를 추가하면 MITM 방어가 강화됩니다.
+> **중요:** 기존 SSH 관련 Secrets(`DEV_HOST`, `DEV_SSH_KEY` 등)은 self-hosted 배포에 **필요하지 않습니다**.
 
 ---
 
@@ -93,21 +86,20 @@ docker compose version
 
 ```
 
-1. **배포 디렉토리 준비**
+2. **배포 디렉토리 준비**
 
 ```bash
 sudo mkdir -p /srv/momuzzi
-sudo chown <ssh-user>:<ssh-user> /srv/momuzzi
-# 예: ubuntu 사용자라면 ubuntu:ubuntu
+sudo chown ubuntu:ubuntu /srv/momuzzi
 
 ```
 
-1. **compose 파일 배치**
+3. **compose 파일 배치**
 
-- 방법 A) 서버에 레포를 클론하여 `/srv/momuzzi/deploy/compose.yaml` 경로 유지
-- 방법 B) `deploy/` 폴더만 서버로 복사
+서버에 레포를 클론하거나, 로컬에서 `deploy/compose.yaml`을 서버로 복사하여
+`/srv/momuzzi/deploy/compose.yaml` 경로 유지
 
-1. (권장) **ubuntu를 docker 그룹에 추가**
+4. (권장) **ubuntu를 docker 그룹에 추가**
 
 ```bash
 sudo usermod -aG docker ubuntu
@@ -115,18 +107,21 @@ sudo usermod -aG docker ubuntu
 
 ```
 
-1. **배포 키 등록**(백엔드/인프라 팀이 수행)
-
-- 프론트가 제공한 `deploy_key.pub` **한 줄 전체**를 서버의 `~/.ssh/authorized_keys`에 추가
+5. **Self-Hosted Runner 설치 (레포 기준)**
 
 ```bash
-mkdir -p ~/.ssh && chmod 700 ~/.ssh
-touch ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys
-echo "<deploy_key.pub 한 줄>" >> ~/.ssh/authorized_keys
+mkdir -p ~/actions-runner && cd ~/actions-runner
+curl -o actions-runner-linux-x64-2.320.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.320.0/actions-runner-linux-x64-2.320.0.tar.gz
+tar xzf actions-runner-linux-x64-2.320.0.tar.gz
 
+# 레포 Settings → Actions → Runners → New self-hosted runner 에서 토큰 발급
+./config.sh --url https://github.com/<OWNER>/<REPO> --token <RUNNER_TOKEN>
+sudo ./svc.sh install
+sudo ./svc.sh start
 ```
 
----
+- 러너 라벨: 기본(self-hosted, Linux, X64) 사용.
+- GitHub → Settings → Actions → Runners에서 Online 상태 확인.
 
 ## compose 설정
 
@@ -156,23 +151,14 @@ services:
 
 ---
 
-## Dockerfile(요약)
-
-- `node:22-alpine` 기반 멀티 스테이지
-- `corepack`으로 pnpm 고정 (`ARG PNPM_VERSION`)
-- Next.js **standalone** 빌드 결과만 런타임 이미지에 포함
-- `HEALTHCHECK` 포함, `node server.js`로 기동
-
----
-
 ## 개발자 플로우
 
 ### 1) 자동 배포
 
-- **feat/** 브랜치에 push → DEV 자동 배포
-- **main** 브랜치에 push → PROD 자동 배포
+- feat/ 브랜치에 push → DEV 자동 배포 (self-hosted runner)
+- main 브랜치에 push → PROD 자동 배포 (self-hosted runner)
 
-### 2) 수동 배포(서버에서)
+### 2) 수동 배포 (서버에서)
 
 ```bash
 export IMAGE=docker.io/journey1019/depromeet-team3:sha-<7자리>
@@ -183,8 +169,6 @@ IMAGE="$IMAGE" docker compose -f deploy/compose.yaml up -d web
 ```
 
 ### 3) 롤백
-
-- 원하는 과거 커밋의 `sha-<7>` 태그로 재기동
 
 ```bash
 export IMAGE=docker.io/journey1019/depromeet-team3:sha-<이전7자리>
@@ -200,80 +184,27 @@ docker logs -f web
 
 ```
 
----
-
-## 로컬 스모크 테스트(옵션)
-
-Apple Silicon(M1/M2)에서 amd64 이미지를 돌릴 때:
-
-```bash
-TAG=sha-xxxxxxx
-IMG=docker.io/journey1019/depromeet-team3:$TAG
-docker pull --platform=linux/amd64 "$IMG"
-docker run --platform=linux/amd64 -d --rm --name web -p 3001:3000 "$IMG"
-curl -I http://127.0.0.1:3001 | head -n1
-docker stop web
-
-```
-
----
-
-## 레지스트리 전환(NCP 사설 레지스트리)
-
-- `REGISTRY=registry.momuzzi.site`
-- `IMAGE_REPO=<네임스페이스>/<레포>`
-- 서버/Actions 모두 `docker login registry.momuzzi.site` 로 조정
-- SSL/TLS 인증서(정상) 필요
-
----
-
-## 멀티아키 빌드(선택)
-
-GitHub Actions에서:
+### 멀티아키 빌드 (선택)
 
 ```yaml
 - uses: docker/setup-qemu-action@v3
 - uses: docker/build-push-action@v6
   with:
     platforms: linux/amd64,linux/arm64
-    cache-from: type=gha
-    cache-to: type=gha,mode=max
 ```
 
-> 네이티브 모듈(sharp 등) 사용 시 Alpine에서 리빌드가 필요할 수 있음.
+### 트러블슈팅
 
----
+- Actions 배포 잡이 :sha-xxxx 형태의 이미지로 실패
+  - docker.yml의 deploy-dev에서 IMAGE를 다음 패턴으로 직접 조립하는지 확인:
 
-## 트러블슈팅(자주 만난 케이스)
+```
+{REGISTRY}/{IMAGE_REPO}:sha-{SHORT_SHA}
+```
 
-- **no matching manifest for linux/arm64**
-
-  → 로컬이 ARM인데 이미지가 amd64 전용. `--platform=linux/amd64`로 실행하거나 멀티아키로 빌드.
-
-- **Bind for 0.0.0.0:3000 failed: port is already allocated**
-
-  → 포트 충돌. 기존 컨테이너 종료 또는 `ports: "3001:3000"`로 변경.
-
-- **Cannot connect to the Docker daemon**
-
-  → Docker 데몬 미기동. Docker Desktop/서비스 재시작, `docker context use desktop-linux`.
-
-- **can't connect without a private SSH key or password**
-
-  → Actions의 `key:`(개인키) 누락. `DEV_SSH_KEY` Secrets 재확인.
-
-- **Permission denied (publickey)** 또는 **Broken pipe**
-
-  → 서버 `~/.ssh/authorized_keys`에 공개키 미등록 또는 권한(700/600) 문제.
-
-- **IMAGE 변수 미설정으로 compose 실패**
-
-  → 배포 시 `IMAGE='<레포:태그>' docker compose ...` 형태로 주입 필요(워크플로에서 처리).
-
----
-
-## 부록: 팀 공유용 요약(한 줄)
-
-> CI는 GitHub Actions, CD는 NCP VM(SSH+Docker Compose).
->
-> 도커 이미지는 Docker Hub에 `latest/sha-<7>`로 푸시, 서버는 `deploy/compose.yaml`로 기동.
+- Cannot connect to Docker daemon
+  - ubuntu가 docker 그룹에 포함되어 있는지 확인, 데몬 실행 상태 확인.
+- 포트 충돌
+  - compose의 ports를 "3001:3000" 등으로 변경.
+- 외부 접속 불가
+  - NCP 보안그룹/ufw에서 3000/tcp 허용 여부 확인.

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -1,13 +1,18 @@
 services:
   web:
-    image: ${IMAGE}
+    image: ${IMAGE}            # Actions에서 IMAGE='레포:태그'로 주입됨
     ports:
-      - "3000:3000"
+      - "3000:3000"            # dev와 충돌나면 "3001:3000" 등으로 조정
     environment:
       NODE_ENV: production
+      # HOSTNAME/PORT는 Dockerfile에서 이미 기본값 지정(0.0.0.0 / 3000)
+      # 필요 시 여기서 덮어써도 됨
     restart: unless-stopped
     healthcheck:
+      # Alpine busybox wget 사용. curl 선호면 curl -f http://127.0.0.1:3000 || exit 1
       test: [ "CMD-SHELL", "wget -qO- http://127.0.0.1:3000/ >/dev/null 2>&1 || exit 1" ]
       interval: 10s
       timeout: 3s
       retries: 5
+      start_period: 10s        # (옵션) 기동 초기 유예
+

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -6,3 +6,8 @@ services:
     environment:
       NODE_ENV: production
     restart: unless-stopped
+    healthcheck:
+      test: [ "CMD-SHELL", "wget -qO- http://127.0.0.1:3000/ >/dev/null 2>&1 || exit 1" ]
+      interval: 10s
+      timeout: 3s
+      retries: 5

--- a/deploy/compose.yaml
+++ b/deploy/compose.yaml
@@ -1,0 +1,8 @@
+services:
+  web:
+    image: ${IMAGE}
+    ports:
+      - "3000:3000"
+    environment:
+      NODE_ENV: production
+    restart: unless-stopped

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  /** Next 빌드 아웃풋 최적화 (standalone) */
+  output: 'standalone',
+  // (옵션) 이미지 외부 도메인 쓰면 domains 등록 필요
+  // images: { remotePatterns: [{ protocol: 'https', hostname: '...'}] },
 };
 
 export default nextConfig;


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
CI/CD 파이프라인 구축
<!-- closes #35  -->

## 📋 작업 내용
- 배포 방식: GitHub 호스티드 러너 → Self-Hosted Runner(NCP VM 내부)
- 실행/검증 방법
  - DEV 자동 배포: feat/* 브랜치에 push → docker(build/push) + deploy-dev(self-hosted) 실행
  - PROD 자동 배포: main 브랜치에 push → docker + deploy-prod 실행
    - 지금 yml은 if: github.ref == 'refs/heads/main' 조건이라 main push일 때만 prod 배포가 돕니다.
  - 수동 실행: Actions → “Build & Push Docker” → Run workflow


## 🔧 변경 사항

- [ ] 💡 비즈니스 로직 (src/, app/ 등)
- [ ] 📦 의존성 (package.json)
- [x] 📃 문서 (README.md 등)
- [ ] 🔥 파일 및 코드 삭제
- [x] 🧹 그 외 ex) .gitignore 등


## 📄 기타

- Secrets Key: `REGISTRY_USER`, `REGISTRY_PASSWORD`, `DEV_USER`, `DEV_PROJECT_DIR`
- 자세한 사항은 **배포용 문서 `README_deploy.md`**  참고


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - Docker 기반 배포 지원 추가: 멀티스테이지 빌드로 생성된 경량 런타임 이미지와 헬스체크를 포함한 컨테이너 실행을 지원합니다.
  - Docker Compose 서비스 제공: 기본 3000 포트 노출, 프로덕션 환경 변수 설정, 자동 재시작 정책 적용.

- 작업(Chores)
  - Docker 빌드 컨텍스트 최적화: 불필요한 파일/캐시 제외로 빌드 속도 및 이미지 효율 개선.
  - 빌드 캐싱과 종속성 분리로 재빌드 성능 향상, 비루트 사용자 실행으로 보안성 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->