### PR TITLE
[Chore] 배포 compose 경로 변경 (deploy → module-infrastructure/nextjs)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,8 @@ name: Build & Deploy Docker
 
 on:
   push:
-    branches: [ main ] # main 브랜치에서만 실행
-    tags: [ 'v*' ] # 태그 push 시 실행 (선택)
+    branches: [main] # main 브랜치에서만 실행
+    tags: ['v*'] # 태그 push 시 실행 (선택)
   workflow_dispatch: {} # 수동 실행 지원
 
 concurrency:
@@ -82,7 +82,6 @@ jobs:
       - name: Show image digest
         run: echo "Pushed digest ${{ steps.build.outputs.digest }}"
 
-
   deploy-prod:
     name: Deploy to PROD (self-hosted)
     needs: docker
@@ -107,9 +106,9 @@ jobs:
       - name: Deploy with compose
         run: |
           set -Eeuo pipefail
-          test -f "$PROJECT_DIR/deploy/compose.yaml" || { echo "compose.yaml not found"; exit 1; }
+          test -f "$PROJECT_DIR/module-infrastructure/nextjs/compose.yaml" || { echo "compose.yaml not found"; exit 1; }
           cd "$PROJECT_DIR"
-          IMAGE='${{ env.IMAGE }}' docker compose -f deploy/compose.yaml pull web
-          IMAGE='${{ env.IMAGE }}' docker compose -f deploy/compose.yaml up -d web
+          IMAGE='${{ env.IMAGE }}' docker compose -f module-infrastructure/nextjs/compose.yaml pull web
+          IMAGE='${{ env.IMAGE }}' docker compose -f module-infrastructure/nextjs/compose.yaml up -d web
           sleep 2
           curl -fsS http://127.0.0.1:3000 >/dev/null && echo "Health OK" || (docker logs web --tail=200 && exit 1)


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

NCP 서버 내 compose.yaml 경로가 변경됨에 따라
GitHub Actions 배포 워크플로우(.github/workflows/docker.yml)의 경로를 수정했습니다.
- `srv/momuzzi/deploy/compose.yaml` → `srv/momuzzi/module-infrastructure/nextjs/compose.yaml`

## 🔧 변경 사항

- [ ] 💡 비즈니스 로직 (src/, app/ 등)
- [ ] 📦 의존성 (package.json)
- [ ] 📃 문서 (README.md 등)
- [ ] 🔥 파일 및 코드 삭제
- [x] 🧹 그 외 ex) .gitignore 등
<br/>

- 기존 deploy/compose.yaml 경로 → module-infrastructure/nextjs/compose.yaml 로 수정
- PROJECT_DIR 값은 동일 (/srv/momuzzi)
- self-hosted runner 배포 시 해당 경로 기준으로 docker compose 실행되도록 반영