### PR TITLE
[Fix] Chore 배포 compose 경로 변경 Secret Key ('srv/momuzzi' 제거)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -106,9 +106,9 @@ jobs:
       - name: Deploy with compose
         run: |
           set -Eeuo pipefail
-          test -f "$PROJECT_DIR/module-infrastructure/nextjs/compose.yaml" || { echo "compose.yaml not found"; exit 1; }
           cd "$PROJECT_DIR"
-          IMAGE='${{ env.IMAGE }}' docker compose -f module-infrastructure/nextjs/compose.yaml pull web
-          IMAGE='${{ env.IMAGE }}' docker compose -f module-infrastructure/nextjs/compose.yaml up -d web
+          test -f "compose.yaml" || { echo "compose.yaml not found"; exit 1; }
+          IMAGE='${{ env.IMAGE }}' docker compose -f compose.yaml pull web
+          IMAGE='${{ env.IMAGE }}' docker compose -f compose.yaml up -d web
           sleep 2
           curl -fsS http://127.0.0.1:3000 >/dev/null && echo "Health OK" || (docker logs web --tail=200 && exit 1)


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
GitHub Actions 배포 환경에서 PROJECT_DIR 경로 변경 
- 기존: /srv/momuzzi
- 변경: (module-infrastructure/nextjs

## 🔧 변경 사항

- [ ] 💡 비즈니스 로직 (src/, app/ 등)
- [ ] 📦 의존성 (package.json)
- [ ] 📃 문서 (README.md 등)
- [ ] 🔥 파일 및 코드 삭제
- [x] 🧹 그 외 ex) .gitignore 등
<br/>
- PROJECT_DIR 값을 `/module-infrastructure/nextjs`로 변경
- `.github/workflows/docker.yml` 내 Deploy with compose 단계에서
cd "$PROJECT_DIR" 후 compose.yaml 직접 실행하도록 수정
