### PR TITLE
[Chore] Github Actions의 compose 경로를 서버에 맞춰 변경

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,5 +108,5 @@ jobs:
         run: |
           cd "$PROJECT_DIR"
           sed -i "s|^IMAGE=.*|IMAGE=${{ env.IMAGE }}|" .env
-          docker compose -f deploy/compose.yaml pull web
-          docker compose -f deploy/compose.yaml up -d web
+          docker compose -f module-infrastructure/nextjs/compose.yaml pull web
+          docker compose -f module-infrastructure/nextjs/compose.yaml up -d web


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
- 현재 에러 원인: GitHub Actions에서 `deploy/compose.yaml`을 찾을 수 없음
- 해결 방법: Actions의 경로를 실제 서버 경로(`module-infrastructure/nextjs/compose.yaml`)로 수정


## 🔧 변경 사항

- [ ] 💡 비즈니스 로직 (src/, app/ 등)
- [ ] 📦 의존성 (package.json)
- [ ] 📃 문서 (README.md 등)
- [ ] 🔥 파일 및 코드 삭제
- [x] 🧹 그 외 ex) .gitignore 등
