### PR TITLE
[Chore] compose.yaml 절대경로 지정

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -106,7 +106,6 @@ jobs:
         run: echo '${{ secrets.REGISTRY_PASSWORD }}' | docker login "$REGISTRY" -u '${{ secrets.REGISTRY_USER }}' --password-stdin
       - name: Update image tag in .env
         run: |
-          cd "$PROJECT_DIR"
-          sed -i "s|^IMAGE=.*|IMAGE=${{ env.IMAGE }}|" .env
-          docker compose -f module-infrastructure/nextjs/compose.yaml pull web
-          docker compose -f module-infrastructure/nextjs/compose.yaml up -d web
+          sed -i "s|^IMAGE=.*|IMAGE=${{ env.IMAGE }}|" /srv/momuzzi/module-infrastructure/nextjs/.env
+          docker compose -f /srv/momuzzi/module-infrastructure/nextjs/compose.yaml pull web
+          docker compose -f /srv/momuzzi/module-infrastructure/nextjs/compose.yaml up -d web


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안
## 📋 작업 내용

- 에러 원인: docker compose가 지정한 module-infrastructure/nextjs/compose.yaml 파일을 서버에서 찾지 못함
- 해결 방법: compose.yaml의 절대경로 직접 지정

## 🔧 변경 사항

- [ ] 💡 비즈니스 로직 (src/, app/ 등)
- [ ] 📦 의존성 (package.json)
- [ ] 📃 문서 (README.md 등)
- [ ] 🔥 파일 및 코드 삭제
- [x] 🧹 그 외 ex) .gitignore 등
