### PR TITLE
[Chore] Docker 배포 파이프라인 수정: latest 태그 고정 및 경로 구조 정리

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,7 +53,6 @@ jobs:
           # - 태그 이벤트(v*): 그 태그 이름으로도 푸시
           tags: |
             type=raw,value=latest,enable=true
-            type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=sha-${{ steps.vars.outputs.SHORT_SHA }}
             type=ref,event=tag
 
@@ -74,9 +73,6 @@ jobs:
         id: outs
         run: |
           set -e
-          if [ -z "${{ env.REGISTRY }}" ] || [ -z "${{ env.IMAGE_REPO }}" ]; then
-            echo "REGISTRY or IMAGE_REPO is empty"; exit 1
-          fi
           echo "IMAGE_URL=${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}" >> "$GITHUB_OUTPUT"
           echo "Resolved IMAGE_URL=${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}"
 
@@ -97,5 +93,6 @@ jobs:
         run: echo '${{ secrets.REGISTRY_PASSWORD }}' | docker login "$REGISTRY" -u '${{ secrets.REGISTRY_USER }}' --password-stdin
       - name: Deploy latest image
         run: |
-          docker compose -f /srv/momuzzi/module-infrastructure/nextjs/compose.yaml pull web
-          docker compose -f /srv/momuzzi/module-infrastructure/nextjs/compose.yaml up -d web
+          cd "$PROJECT_DIR"
+          docker compose -f module-infrastructure/nextjs/compose.yaml pull web
+          docker compose -f module-infrastructure/nextjs/compose.yaml up -d web


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

- Docker 이미지 태그 고정
- 배포 스크립트 경로 정리
  - 절대경로(/srv/momuzzi/...) → 상대경로(module-infrastructure/nextjs/compose.yaml) 변경
  - cd "$PROJECT_DIR" 후 상대경로 기반으로 Compose 실행

## 🔧 변경 사항

- [ ] 💡 비즈니스 로직 (src/, app/ 등)
- [ ] 📦 의존성 (package.json)
- [ ] 📃 문서 (README.md 등)
- [ ] 🔥 파일 및 코드 삭제
- [x] 🧹 그 외 ex) .gitignore 등
