### PR TITLE
[Chore] latest가 아닌 digest를 활용해 이미지 재사용

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,13 +54,15 @@ jobs:
             NEXT_PUBLIC_KAKAO_REDIRECT_URL=${{ secrets.NEXT_PUBLIC_KAKAO_REDIRECT_URL }}
             NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}
 
-      - name: Show pushed digest
+      - name: Show pushed digest and image info
         run: |
           echo "Docker Image Build Complete"
           echo "Digest: ${{ steps.build.outputs.digest }}"
           echo "Image Tags:"
           echo " - ${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}:latest"
           echo " - ${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}:sha-${{ steps.vars.outputs.SHORT_SHA }}"
+          echo "Verify image on Docker Hub:"
+          echo "   https://hub.docker.com/r/journey1019/depromeet-team3/tags"
 
   deploy-prod:
     name: Deploy to PROD (self-hosted)
@@ -72,14 +74,16 @@ jobs:
     env:
       PROJECT_DIR: ${{ secrets.PROD_PROJECT_DIR }}
       REGISTRY: ${{ vars.REGISTRY || 'docker.io' }}
+      IMAGE_REPO: journey1019/depromeet-team3
 
     steps:
       - name: Docker Login
         run: echo '${{ secrets.REGISTRY_PASSWORD }}' | docker login "$REGISTRY" -u '${{ secrets.REGISTRY_USER }}' --password-stdin
 
-      - name: Deploy latest image
+      - name: Deploy latest image by digest
         run: |
           COMPOSE_FILE="$PROJECT_DIR/module-infrastructure/nextjs/compose.yaml"
+          IMAGE_SHA_TAG="sha-${{ needs.docker.outputs.SHORT_SHA || github.sha::7 }}"
 
           if [ ! -f "$COMPOSE_FILE" ]; then
             echo "❌ ERROR: Compose file not found at $COMPOSE_FILE"
@@ -90,19 +94,27 @@ jobs:
 
           echo "✅ Found compose.yaml at $COMPOSE_FILE"
 
-          echo "🧹 Removing old image cache..."
+          echo "🧾 Updating compose.yaml to use specific digest tag..."
+          sed -i "s|journey1019/depromeet-team3:.*|journey1019/depromeet-team3:${IMAGE_SHA_TAG}|" "$COMPOSE_FILE"
+
+          echo "🧹 Removing old containers and images..."
+          docker rm -f deploy-web-1 || true
+          docker compose -f "$COMPOSE_FILE" down || true
           docker image rm -f journey1019/depromeet-team3:latest || true
 
-          echo "📦 Pulling latest Docker image..."
-          docker compose -f "$COMPOSE_FILE" pull web
+          echo "📦 Pulling latest image by tag..."
+          docker compose -f "$COMPOSE_FILE" pull --ignore-pull-failures web
 
-          echo "🧨 Removing old container if exists..."
-          docker rm -f deploy-web-1 || true
+          echo "🚀 Recreating container with latest digest..."
+          docker compose -f "$COMPOSE_FILE" up -d --force-recreate web
 
-          echo "🧩 Stopping old containers (safety fallback)..."
-          docker compose -f "$COMPOSE_FILE" down || true
+          echo "🧠 Current Docker image versions:"
+          docker images | grep journey1019/depromeet-team3 || echo "(no image found)"
+          echo ""
+          echo "🔎 Running containers info:"
+          docker ps --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}'
+          echo ""
+          echo "🔍 Active image digest:"
+          docker inspect deploy-web-1 --format '{{.Image}}' || true
 
-          echo "🚀 Restarting container with latest image..."
-          docker compose -f "$COMPOSE_FILE" up -d web
-
-          echo "✅ Deployment successful"
+          echo "✅ Deployment completed successfully 🚀"


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용

① 항상 최신 digest pull | docker compose pull --ignore-pull-failures + --force-recreate
② digest 기반 배포 고정 | sed 명령으로 compose.yaml의 image: 줄을 sha-<SHORT_SHA>로 자동 치환
③ 확인 명령 자동 실행 | 배포 후 docker images, docker ps, docker inspect 로 현재 digest 출력

## 🔧 변경 사항

- [ ] 💡 비즈니스 로직 (src/, app/ 등)
- [ ] 📦 의존성 (package.json)
- [ ] 📃 문서 (README.md 등)
- [ ] 🔥 파일 및 코드 삭제
- [x] 🧹 그 외 ex) .gitignore 등
