### PR TITLE
[Fix] ${{ github.sha::7 }} 제거 -> format 함수

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,6 +21,9 @@ jobs:
       REGISTRY: ${{ vars.REGISTRY || 'docker.io' }}
       IMAGE_REPO: ${{ vars.IMAGE_REPO || 'journey1019/depromeet-team3' }}
 
+    outputs:
+      SHORT_SHA: ${{ steps.vars.outputs.SHORT_SHA }}
+
     steps:
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -56,12 +59,12 @@ jobs:
 
       - name: Show pushed digest and image info
         run: |
-          echo "Docker Image Build Complete"
+          echo "✅ Docker Image Build Complete"
           echo "Digest: ${{ steps.build.outputs.digest }}"
           echo "Image Tags:"
           echo " - ${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}:latest"
           echo " - ${{ env.REGISTRY }}/${{ env.IMAGE_REPO }}:sha-${{ steps.vars.outputs.SHORT_SHA }}"
-          echo "Verify image on Docker Hub:"
+          echo "🔍 Verify image on Docker Hub:"
           echo "   https://hub.docker.com/r/journey1019/depromeet-team3/tags"
 
   deploy-prod:
@@ -83,7 +86,8 @@ jobs:
       - name: Deploy latest image by digest
         run: |
           COMPOSE_FILE="$PROJECT_DIR/module-infrastructure/nextjs/compose.yaml"
-          IMAGE_SHA_TAG="sha-${{ needs.docker.outputs.SHORT_SHA || github.sha::7 }}"
+          IMAGE_SHA_TAG="sha-${{ needs.docker.outputs.SHORT_SHA || github.sha }}"
+          IMAGE_SHA_TAG=$(echo "$IMAGE_SHA_TAG" | cut -c1-11)
 
           if [ ! -f "$COMPOSE_FILE" ]; then
             echo "❌ ERROR: Compose file not found at $COMPOSE_FILE"


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 📋 작업 내용
- github.sha::7 제거
  - GitHub Expressions에서 substring 불가. 대신 cut 사용.
- IMAGE_SHA_TAG 동적 계산	
  - Actions → Bash 내부에서 cut -c1-11로 슬라이스.
- jobs.docker.outputs.SHORT_SHA 연결	
  - outputs: 추가해 needs.docker.outputs.SHORT_SHA로 전달.
- digest 기반 배포 유지	
  - sed로 compose 파일 수정 (journey1019/depromeet-team3:sha-xxxxxxx).
- 최신 digest 강제 pull	
  - docker compose pull + --force-recreate 사용.
- 배포 후 검증	
  - docker images, docker ps, docker inspect 출력.

## 🔧 변경 사항

- [ ] 💡 비즈니스 로직 (src/, app/ 등)
- [ ] 📦 의존성 (package.json)
- [ ] 📃 문서 (README.md 등)
- [ ] 🔥 파일 및 코드 삭제
- [x] 🧹 그 외 ex) .gitignore 등
